### PR TITLE
fix handling of spaces in file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # beluga-cli
 
-v0.6.3
+v0.6.4
 
 ## overview:
 

--- a/beluga-cli
+++ b/beluga-cli
@@ -115,7 +115,7 @@ beluga_api ( ) {
     isodate=$(date -u "+%Y-%m-%dT%H:%M:%S.%6NZ")
   fi
 
-  # TOKEN AUTHENTICATION (MUCH BETTER... BUT I CAN'T GET IT WORKING)
+  # TOKEN AUTHENTICATION
   local signstring="$requestmethod:$requestpath:$isodate"
 
   if [[ ( $requestmethod == 'POST' || $requestmethod == 'PUT' ) && ! -z $requestbody ]]; then
@@ -169,6 +169,7 @@ display_message ( ) {
         if [[ `echo -e $line | sed "s,$(printf '\033')\\[[0-9;]*[a-zA-Z],,g" | awk '{print length}'` -gt $(tput cols) ]]; then
           if [[ $line =~ "http://$cdnurl" ]]; then
             line=${line//http:\/\/$cdnurl/cdn:/}
+            line=${line//%20/ }
           fi
         fi
 

--- a/beluga-cli
+++ b/beluga-cli
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # beluga-cli
-VERSION_NUMBER="v0.6.3"
+VERSION_NUMBER="v0.6.4"
 # exit codes:
 #  0 success
 #  1 failure: operation aborted

--- a/beluga-cli
+++ b/beluga-cli
@@ -931,7 +931,7 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
 
   if [[ $mode == "rename" ]]; then
     if [[ -z $source ]]; then
-      msg="\033[31;1mfailed:\033[0m http://$cdnurl/ -> http://$cdnurl/$destination"$'\n'"is a directory: http://$cdnurl/"
+      msg="\033[31;1mfailed:\033[0m http://$cdnurl/ -> http://$cdnurl/${destination// /%20}"$'\n'"is a directory: http://$cdnurl/"
       display_message "$msg" >&2
       exit 1
     elif [[ ${source:$(expr ${#source} - 1)} == '/' ]]; then
@@ -942,7 +942,7 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
     result=$?
 
     if [[ $result -eq 0 ]]; then
-      msg="\033[31;1mfailed:\033[0m http://$cdnurl/$source/ -> http://$cdnurl/$destination"$'\n'"is a directory: http://$cdnurl/$source/"
+      msg="\033[31;1mfailed:\033[0m http://$cdnurl/${source// /%20}/ -> http://$cdnurl/${destination// /%20}"$'\n'"is a directory: http://$cdnurl/${source// /%20}/"
       display_message "$msg" >&2
       exit 1
     else
@@ -963,11 +963,11 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
       fi
 
       if [[ $curroperation == 'mv' ]]; then
-        msg="\033[1;92mmoving:\033[0m http://$cdnurl/$source -> http://$cdnurl/$destination"
+        msg="\033[1;92mmoving:\033[0m http://$cdnurl/${source// /%20} -> http://$cdnurl/${destination// /%20}"
         curl "ftp://$serverdefault/$source" -Q "-DELE $sourcefile" > "$HOME/.beluga-cli/.curltmp" 2> /dev/null
         result=$?
       elif [[ $curroperation == 'cp' ]]; then
-        msg="\033[1;92mcopying:\033[0m http://$cdnurl/$source -> http://$cdnurl/$destination"
+        msg="\033[1;92mcopying:\033[0m http://$cdnurl/${source// /%20} -> http://$cdnurl/${destination// /%20}"
         curl "ftp://$serverdefault/$source" > "$HOME/.beluga-cli/.curltmp" 2> /dev/null
         result=$?
       fi
@@ -1014,7 +1014,7 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
         remote+='/'
       fi
 
-      msg="\033[31;1mfailed:\033[0m $local -> http://$cdnurl/$remote"$'\n'"does not exist: $local"
+      msg="\033[31;1mfailed:\033[0m $local -> http://$cdnurl/${remote// /%20}"$'\n'"does not exist: $local"
       display_message "$msg" >&2
 
       exit 1
@@ -1028,7 +1028,7 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
         remote="$remote/"
       fi
 
-      msg="\033[31;1mfailed:\033[0m $local/ -> http://$cdnurl/$remote"$'\n'"is a directory: $local/"
+      msg="\033[31;1mfailed:\033[0m $local/ -> http://$cdnurl/${remote// /%20}"$'\n'"is a directory: $local/"
 
       display_message "$msg" >&2
       exit 1
@@ -1048,7 +1048,7 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
         if [[ $mode == "down" ]]; then
           if [[ $primarycmd == 'rm' ]]; then
             if [[ $inputflags =~ 'r' ]]; then
-              msg="\033[1;92mdeleting:\033[0m http://$cdnurl/$remote/"
+              msg="\033[1;92mdeleting:\033[0m http://$cdnurl/${remote// /%20}/"
               display_message "$msg"
 
               recursive_delete $remote
@@ -1059,10 +1059,10 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
               elif [[ $result -eq 5 ]]; then
                 msg="\033[1;33mpartly \033[1;33mfailed:\033[0m some files not deleted"
               else
-                msg="\033[31;1mfailed:\033[0m http://$cdnurl/$remote/ not deleted"
+                msg="\033[31;1mfailed:\033[0m http://$cdnurl/${remote// /%20}/ not deleted"
               fi
             elif [[ -z "$dircontents" ]]; then
-              msg="\033[1;92mdeleting:\033[0m http://$cdnurl/$remote/"
+              msg="\033[1;92mdeleting:\033[0m http://$cdnurl/${remote// /%20}/"
               display_message "$msg"
               curl -l "ftp://$serverdefault/" -Q "-RMD $remote" > /dev/null 2> /dev/null
               result=$?
@@ -1071,13 +1071,13 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
               word_wrap $(tput cols) 0  "$validationresult" >&2
               exit $result
             else
-              msg="\033[1;92mdeleting:\033[0m http://$cdnurl/$remote/"
+              msg="\033[1;92mdeleting:\033[0m http://$cdnurl/${remote// /%20}/"
               display_message "$msg" >&2
               msg="\033[31;1mfailed:\033[0m operation not completed [directory not empty]"
               result=1
             fi
           else
-            msg="\033[31;1mfailed:\033[0m http://$cdnurl/$remote/ -> $local"$'\n'"is a directory: http://$cdnurl/$remote/"
+            msg="\033[31;1mfailed:\033[0m http://$cdnurl/${remote// /%20}/ -> $local"$'\n'"is a directory: http://$cdnurl/${remote// /%20}/"
             result=1
           fi
 
@@ -1104,7 +1104,7 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
           if [[ $remoteendchar == '/' ]]; then
             # if the user included a / where there shouldn't be one,
             # tell them the verbatim file doesn't exist (even if it otherwise might)
-            msg="\033[31;1mfailed:\033[0m http://$cdnurl/$remote/ -> $local"$'\n'"does not exist: $remote/"
+            msg="\033[31;1mfailed:\033[0m http://$cdnurl/${remote// /%20}/ -> $local"$'\n'"does not exist: $remote/"
             display_message "$msg" >&2
             exit 1
           fi
@@ -1126,11 +1126,11 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
 
     if [[ $mode == "up" ]]; then
       if [[ $curroperation == "cp" ]]; then
-        msg="\033[1;92muploading:\033[0m $local -> http://$cdnurl/$remote"
+        msg="\033[1;92muploading:\033[0m $local -> http://$cdnurl/${remote// /%20}"
         curl -T "$local" "ftp://$serverdefault/$remote" --ftp-create-dirs 2> /dev/null
         result=$?
       elif [[ $curroperation == "mv" ]]; then
-        msg="\033[1;92mmoving:\033[0m $local -> http://$cdnurl/$remote"
+        msg="\033[1;92mmoving:\033[0m $local -> http://$cdnurl/${remote// /%20}"
         curl -T "$local" "ftp://$serverdefault/$remote" --ftp-create-dirs 2> /dev/null
         result=$?
         if [[ $result -eq 0 ]]; then
@@ -1178,14 +1178,14 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
       fi
 
       if [[ $curroperation == "cp" ]]; then
-        msg="\033[1;92mdownloading:\033[0m http://$cdnurl/$remote -> $local"
+        msg="\033[1;92mdownloading:\033[0m http://$cdnurl/${remote// /%20} -> $local"
         curl "ftp://$serverdefault/$remote" -o "$local" 2> /dev/null
         result=$?
       elif [[ $curroperation == "mv" ]]; then
         if [[ $primarycmd == 'rm' ]]; then
-          msg="\033[1;92mdeleting:\033[0m http://$cdnurl/$remote"
+          msg="\033[1;92mdeleting:\033[0m http://$cdnurl/${remote// /%20}"
         else
-          msg="\033[1;92mmoving:\033[0m http://$cdnurl/$remote -> $local"
+          msg="\033[1;92mmoving:\033[0m http://$cdnurl/${remote// /%20} -> $local"
         fi
         curl "ftp://$serverdefault/$remote" -Q "-DELE $remotefile" -o "$local" 2> /dev/null
         result=$?
@@ -1232,7 +1232,7 @@ elif [[ $primarycmd == 'mkdir' ]]; then
   else
     destination="${args[0]:6}"
 
-    display_message "\033[1;92mcreating \033[1;92mdirectory:\033[0m http://$cdnurl/$destination" >&2
+    display_message "\033[1;92mcreating \033[1;92mdirectory:\033[0m http://$cdnurl/${destination// /%20}" >&2
 
     if [[ ${destination:$(expr ${#destination} - 1)} == "/" ]]; then
       destination=${destination:0:$(expr ${#destination} - 1)}
@@ -1387,7 +1387,7 @@ elif [[ $primarycmd == 'ls' || $primarycmd == 'll' ]]; then
     remote+='/'
   fi
 
-  myurl=http://$cdnurl/$remote
+  myurl=http://$cdnurl/${remote// /%20}
 
   msg="\033[1;92mlisting contents of\033[0m $myurl"
 

--- a/beluga-cli
+++ b/beluga-cli
@@ -10,6 +10,8 @@ VERSION_NUMBER="v0.6.3"
 #  4 missing config
 #  5 partial failure
 
+#NB: consider possible utility of "${file##*/*}" and "${file%/*}" (https://en.wikipedia.org/wiki/Dirname) as well as basename (https://en.wikipedia.org/wiki/Basename)
+
 update_self ( ) {
   local msg="checking for new version of beluga-cli"
   word_wrap $(tput cols) 0 "$msg" >&2
@@ -600,7 +602,7 @@ elif [[ $1 != 'rm' && $1 != 'cp' && $1 != 'mv' && $1 != 'iv' && $1 != 'ls' && $1
 else
   count=0
   args=( )
-  for command in $@; do
+  for command in "$@"; do
     if [[ $command == 'rm' || $command == 'cp' || $command == 'mv' || $command == 'iv' || $command == 'ls' || $command == 'll' || $command == 'ftp' || $command == 'mkdir' || $command == 'config' || $command == 'update' ]]; then
       let count+=1
     elif [[ ${command:0:10} == "--profile=" ]]; then
@@ -615,7 +617,7 @@ else
     elif [[ ${command:0:1} == '-' ]]; then
       inputflags+=${command/-/}
     else
-      args=( ${args[@]} $command )
+      args=( "${args[@]}" "$command" )
     fi
   done
 
@@ -839,9 +841,9 @@ elif [[ $primarycmd == 'ftp' ]]; then
     word_wrap $(tput cols) 1 "$msg" >&2
   fi
 
-  if [[ ${args[0]} == 'help' || ${#args[@]} -gt 0 ]]; then
+  if [[ "${args[0]}" == 'help' || ${#args[@]} -gt 0 ]]; then
     word_wrap $(tput cols) 1:0-7 "usage: beluga-cli ftp" >&2
-    if [[ ${args[0]} == 'help' ]]; then
+    if [[ "${args[0]}" == 'help' ]]; then
       word_wrap $(tput cols) 0 "logs on to the origin server in an interactive ftp session." >&2
       word_wrap $(tput cols) 0 "for more detailed help, run \033[1mbeluga-cli \033[1mhelp\033[0m." >&2
       exit 0
@@ -855,9 +857,9 @@ elif [[ $primarycmd == 'ftp' ]]; then
   exit $?
 elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; then
   if [[ $primarycmd == 'rm' ]]; then
-    if [[ ${args[0]} == 'help' || ${#args[@]} -gt 1 || ${#args[@]} -lt 1 || ${args[0]:0:6} != 'cdn://' ]]; then
+    if [[ "${args[0]}" == 'help' || ${#args[@]} -gt 1 || ${#args[@]} -lt 1 || "${args[0]:0:6}" != 'cdn://' ]]; then
       word_wrap $(tput cols) 1:0-7 "usage: beluga-cli rm [-isr] <cdn://uri>" >&2
-      if [[ ${args[0]} == 'help' ]]; then
+      if [[ "${args[0]}" == 'help' ]]; then
         word_wrap $(tput cols) 0 "deletes a file from the origin server." >&2
         word_wrap $(tput cols) 0 "for more detailed help, run \033[1mbeluga-cli \033[1mhelp\033[0m." >&2
         exit 0
@@ -865,7 +867,7 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
         word_wrap $(tput cols) 0 "\033[31;1millegal input:\033[0m input [beluga-cli $@] includes too few args" >&2
       elif [[ ${#args[@]} -gt 1 ]]; then
         word_wrap $(tput cols) 0 "\033[31;1millegal input:\033[0m input [beluga-cli $@] includes too many args" >&2
-      elif [[ ${args[0]:0:6} != 'cdn://' ]]; then
+      elif [[ "${args[0]:0:6}" != 'cdn://' ]]; then
         word_wrap $(tput cols) 0 "\033[31;1millegal input:\033[0m input [beluga-cli $@] includes no cdn:// uri" >&2
       fi
       exit 3
@@ -881,9 +883,9 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
     fi
 
     curroperation=$primarycmd
-    if [[ ${args[0]} == 'help' || ${#args[@]} -gt 2 || ${#args[@]} -lt 2 || ( ${args[0]:0:6} != 'cdn://' && ${args[1]:0:6} != 'cdn://' ) ]]; then
+    if [[ "${args[0]}" == 'help' || ${#args[@]} -gt 2 || ${#args[@]} -lt 2 || ( "${args[0]:0:6}" != 'cdn://' && "${args[1]:0:6}" != 'cdn://' ) ]]; then
       word_wrap $(tput cols) 1:0-7 "usage: beluga-cli $primarycmd [-is] <localpath> <cdn://uri> or <cdn://uri> <localpath> or <cdn://uri> <cdn://uri>" >&2
-      if [[ ${args[0]} == 'help' ]]; then
+      if [[ "${args[0]}" == 'help' ]]; then
         if [[ $curroperation == 'mv' ]]; then
           word_wrap $(tput cols) 0 "moves a file to, from, or within the origin server: of the source and destination, one or both should be remote uris, formatted with cdn:// preceding the path." >&2
         else
@@ -893,7 +895,7 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
         exit 0
       elif [[ ${#args[@]} -lt 2 ]]; then
         word_wrap $(tput cols) 0 "\033[31;1millegal input:\033[0m input [beluga-cli $@] includes too few args" >&2
-      elif [[ ( ${args[0]:0:6} != 'cdn://' && ${args[1]:0:6} != 'cdn://' ) ]]; then
+      elif [[ ( "${args[0]:0:6}" != 'cdn://' && "${args[1]:0:6}" != 'cdn://' ) ]]; then
         word_wrap $(tput cols) 0 "\033[31;1millegal input:\033[0m input [beluga-cli $@] includes no cdn:// uri" >&2
       elif [[ ${#args[@]} -gt 2 ]]; then
         word_wrap $(tput cols) 0 "\033[31;1millegal input:\033[0m input [beluga-cli $@] includes too many args" >&2
@@ -902,7 +904,7 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
     fi
 
 
-    if [[ ${args[0]:0:6} == 'cdn://' && ${args[1]:0:6} == 'cdn://' ]]; then
+    if [[ "${args[0]:0:6}" == 'cdn://' && ${args[1]:0:6} == 'cdn://' ]]; then
       source=${args[0]#cdn:\/\/}
       destination=${args[1]#cdn:\/\/}
       mode="rename"
@@ -911,7 +913,7 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
         local=${args[0]}
         remote=${args[1]#cdn:\/\/}
         mode="up"
-      elif [[ ${args[0]:0:6} == 'cdn://' ]]; then
+      elif [[ "${args[0]:0:6}" == 'cdn://' ]]; then
         local=${args[1]}
         remote=${args[0]#cdn:\/\/}
         mode="down"
@@ -1214,16 +1216,16 @@ elif [[ $primarycmd == 'mkdir' ]]; then
     fi
   fi
 
-  if [[ ${args[0]} == 'help' || ${#args[@]} -gt 1 || ${#args[@]} -lt 1 || ${args[0]:0:6} != 'cdn://' ]]; then
+  if [[ "${args[0]}" == 'help' || ${#args[@]} -gt 1 || ${#args[@]} -lt 1 || "${args[0]:0:6}" != 'cdn://' ]]; then
     word_wrap $(tput cols) 1:0-7 "usage: beluga-cli $primarycmd [-s] <cdn://uri>" >&2
-    if [[ ${args[0]} == 'help' ]]; then
+    if [[ "${args[0]}" == 'help' ]]; then
       word_wrap $(tput cols) 0 "creates a new directory on the origin server." >&2
       word_wrap $(tput cols) 0 "for more detailed help, run \033[1mbeluga-cli \033[1mhelp\033[0m." >&2
     elif [[ ${#args[@]} -lt 1 ]]; then
       word_wrap $(tput cols) 0 "\033[31;1millegal input:\033[0m input [beluga-cli $@] includes too few args" >&2
     elif [[ ${#args[@]} -gt 1 ]]; then
       word_wrap $(tput cols) 0 "\033[31;1millegal input:\033[0m input [beluga-cli $@] includes too many args" >&2
-    elif [[ ${args[0]:0:6} != 'cdn://' ]]; then
+    elif [[ "${args[0]:0:6}" != 'cdn://' ]]; then
       word_wrap $(tput cols) 0 "\033[31;1millegal input:\033[0m input [beluga-cli $@] includes no cdn:// uri" >&2
     fi
     exit 3
@@ -1331,16 +1333,16 @@ elif [[ $primarycmd == 'iv' ]]; then
     fi
   fi
 
-  if [[ ${args[0]} == 'help' || ${#args[@]} -gt 1 || ${#args[@]} -lt 1 || ${args[0]:0:6} != 'cdn://' ]]; then
+  if [[ "${args[0]}" == 'help' || ${#args[@]} -gt 1 || ${#args[@]} -lt 1 || "${args[0]:0:6}" != 'cdn://' ]]; then
     word_wrap $(tput cols) 1:0-7 "usage: beluga-cli $primarycmd [-s] <cdn://uri>" >&2
-    if [[ ${args[0]} == 'help' ]]; then
+    if [[ "${args[0]}" == 'help' ]]; then
       word_wrap $(tput cols) 0 "invalidates a file so it must be retrieved again from the origin server." >&2
       word_wrap $(tput cols) 0 "for more detailed help, run \033[1mbeluga-cli \033[1mhelp\033[0m." >&2
     elif [[ ${#args[@]} -lt 1 ]]; then
       word_wrap $(tput cols) 0 "\033[31;1millegal input:\033[0m input [beluga-cli $@] includes too few args" >&2
     elif [[ ${#args[@]} -gt 1 ]]; then
       word_wrap $(tput cols) 0 "\033[31;1millegal input:\033[0m input [beluga-cli $@] includes too many args" >&2
-    elif [[ ${args[0]:0:6} != 'cdn://' ]]; then
+    elif [[ "${args[0]:0:6}" != 'cdn://' ]]; then
       word_wrap $(tput cols) 0 "\033[31;1millegal input:\033[0m input [beluga-cli $@] includes no cdn:// uri" >&2
     fi
     exit 3
@@ -1362,16 +1364,16 @@ elif [[ $primarycmd == 'ls' || $primarycmd == 'll' ]]; then
   fi
 
 
-  if [[ ${args[0]} == 'help' || ${#args[@]} -gt 1 || ${#args[@]} -lt 1 || ${args[0]:0:6} != 'cdn://' ]]; then
+  if [[ "${args[0]}" == 'help' || ${#args[@]} -gt 1 || ${#args[@]} -lt 1 || "${args[0]:0:6}" != 'cdn://' ]]; then
     word_wrap $(tput cols) 1:0-7 "usage: beluga-cli $primarycmd [-s] <cdn://uri>" >&2
-    if [[ ${args[0]} == 'help' ]]; then
+    if [[ "${args[0]}" == 'help' ]]; then
       word_wrap $(tput cols) 0 "retrieves and lists the contents of a specified directory on the origin." >&2
       word_wrap $(tput cols) 0 "for more detailed help, run \033[1mbeluga-cli \033[1mhelp\033[0m." >&2
     elif [[ ${#args[@]} -lt 1 ]]; then
       word_wrap $(tput cols) 0 "\033[31;1millegal input:\033[0m input [beluga-cli $@] includes too few args" >&2
     elif [[ ${#args[@]} -gt 1 ]]; then
       word_wrap $(tput cols) 0 "\033[31;1millegal input:\033[0m input [beluga-cli $@] includes too many args" >&2
-    elif [[ ${args[0]:0:6} != 'cdn://' ]]; then
+    elif [[ "${args[0]:0:6}" != 'cdn://' ]]; then
       word_wrap $(tput cols) 0 "\033[31;1millegal input:\033[0m input [beluga-cli $@] includes no cdn:// uri" >&2
     fi
     exit 3


### PR DESCRIPTION
* file paths with (escaped) spaces should now work correctly
* spaces in remote paths displayed in url format will be escaped (i.e. replaced with `%20`)

resolves #17 