### PR TITLE
apply -p flag to cp and mv

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,17 @@ note that the "origin server location" should include the entire path used as th
 
 **caution:** your origin server username and password will be stored & transmitted as plain text, so ensure they are not used elsewhere.
 
-on the other hand, although you will be prompted for your belugacdn username and password if you choose to create a new token during the setup & configuration process, these are only used for generating the token and are not stored anywhere.
+on the other hand, although you will be prompted for your belugacdn username and password if you choose to create a new token during the setup & configuration process, these are only used once (for basic authentication, i.e. transmitted in base64) to generate the token, and are not stored anywhere.
 
 ## possible commands:
 
 ### file manipulation:
 
 **cp** : copy a file to, from, or within the origin, resulting in duplicate copies at the source and destination.  
-usage: `beluga-cli cp [-is] <localpath> <cdn://uri> or <cdn://uri> <localpath> or <cdn://uri> <cdn://uri>`
+usage: `beluga-cli cp [-ips] <localpath> <cdn://uri> or <cdn://uri> <localpath> or <cdn://uri> <cdn://uri>`
 
 **mv** : move a file to, from, or within the server, deleting the original and keeping the new copy.  
-usage: `beluga-cli mv [-is] <localpath> <cdn://uri> or <cdn://uri> <localpath> or <cdn://uri> <cdn://uri>`
+usage: `beluga-cli mv [-ips] <localpath> <cdn://uri> or <cdn://uri> <localpath> or <cdn://uri> <cdn://uri>`
 
 **rm** : delete a remote file or directory.  
 usage: `beluga-cli rm [-irs] <cdn://uri>`
@@ -71,7 +71,7 @@ usage: `beluga-cli config`
 
 **-i** : will invalidate the uri of any file modified by the requested operation. see [origin vs cdn](#origin-vs-cdn) for why this may be useful.
 
-**-p** : create all intermediate directories in the specified path as needed.
+**-p** : create all intermediate directories in the specified path (the destination path, when used with mv or cp commands) as needed.
 
 **-r** : delete all contents of the specified directory recursively.
 
@@ -117,10 +117,10 @@ the following examples should help to demonstrate what normal input and output l
    done
    ```
 
-4. use grep and xargs to download every image file (.png or .jp[e]g) in the dir from the previous example to a local directory named 'cdnimg', with 'cp_' prepended to each local filename:
+4. use grep and xargs to download every image file (.png or .jp[e]g) in the dir from the previous example to a local directory named 'cdnimg' - which is created in the process if it didn't previously exist - with 'cp_' prepended to each local filename:
 
    ```
-   $ beluga-cli ls cdn://images 2> /dev/null | grep -E "\.(jpe?g|png)" | xargs -I % beluga-cli cp cdn://images/% ~/cdnimg/cp_%
+   $ beluga-cli ls cdn://images 2> /dev/null | grep -E "\.(jpe?g|png)" | xargs -I % beluga-cli cp -p cdn://images/% ~/cdnimg/cp_%
    downloading: cdn://images/babypic.jpg -> ~/cdnimg/cp_babypic.jpg
    done
    downloading: cdn://images/logo.png -> ~/cdnimg/cp_logo.png

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # beluga-cli
 
-v0.6.4
+v0.6.5
 
 ## overview:
 

--- a/beluga-cli
+++ b/beluga-cli
@@ -10,8 +10,6 @@ VERSION_NUMBER="v0.6.4"
 #  4 missing config
 #  5 partial failure
 
-#NB: consider possible utility of "${file##*/*}" and "${file%/*}" (https://en.wikipedia.org/wiki/Dirname) as well as basename (https://en.wikipedia.org/wiki/Basename)
-
 update_self ( ) {
   local msg="checking for new version of beluga-cli"
   word_wrap $(tput cols) 0 "$msg" >&2
@@ -873,7 +871,7 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
       exit 3
     fi
 
-    remote=${args[0]#cdn:\/\/}
+    remote="${args[0]#cdn:\/\/}"
     curroperation='mv'
     local='/dev/null'
     mode="down"
@@ -921,12 +919,13 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
     fi
 
     if [[ $local == '.' ]]; then
-      local=$PWD
+      local="$PWD"
     elif [[ ${local:0:2} == './' ]]; then
       local="$PWD/${local:2}"
+    elif [[ ${local:0:3} == '../' ]]; then
+      local="$PWD"
     elif [[ ${local:0:1} == '~' ]]; then
-      local=${local/\~/$HOME}
-      # TODO: is there a situation where this is really needed?
+      local="${local/\~/$HOME}"
     fi
   fi
 
@@ -947,7 +946,7 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
       display_message "$msg" >&2
       exit 1
     else
-      sourcefile=$(expr "//$source" : '.*/\(.*\)')
+      sourcefile=${source##*/}
 
       if [[ ${destination:$(expr ${#destination} - 1)} == '/' ]]; then
         destination+=$sourcefile
@@ -1014,7 +1013,7 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
     fi
   else
     if [[ ! -e $local && $mode == "up" ]]; then
-      remotefile=$(expr "//$remote" : '.*/\(.*\)')
+      remotefile=${remote##*/}
       if [[ ! ( $remotefile =~ '.' || -z $remotefile ) ]]; then
         remote+='/'
       fi
@@ -1024,11 +1023,11 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
 
       exit 1
     elif [[ -d $local && $mode == "up" ]]; then
-      if [[ ${local:$(expr ${#local} - 1):1} == '/' ]]; then
+      if [[ ${local:(-1)} == '/' ]]; then
         local=${local:0:$(expr ${#local} - 1)}
       fi
 
-      remotefile=$(expr "//$remote" : '.*/\(.*\)')
+      remotefile=${remote##*/}
       if [[ ! ( $remotefile =~ '.' || -z $remotefile ) ]]; then
         remote="$remote/"
       fi
@@ -1090,15 +1089,15 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
 
           exit $result # and we are downloading (or deleting)
         elif [[ $mode == "up" ]]; then
-          remote+="/$(expr "//$local" : '.*/\(.*\)')"
+          remote+="/${local##*/}"
         fi
       else # if $remote is not a directory
         if [[ $mode == "up" ]]; then # if uploading
           if [[ $remoteendchar == '/' ]]; then # and the user ended the remote uri with a /
-            remote+="/$(expr "//$local" : '.*/\(.*\)')" # add the local filename to $remote
+            remote+="/${local##*/}" # add the local filename to $remote
           else # if the user didn't end it with a /
-            remotefile=$(expr "//$remote" : '.*/\(.*\)')
-            localfile=$(expr "//$local" : '.*/\(.*\)')
+            remotefile=${remote##*/}
+            localfile=${local##*/}
             if [[ ( ! $remotefile =~ '.' ) && $localfile =~ '.' ]]; then
               # if the local filename has an extension and the remote doesn't,
               # assume it was intended to be a directory
@@ -1117,7 +1116,7 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
       fi
     else
       if [[ $mode == "up" ]]; then
-        remote=$(expr "//$local" : '.*/\(.*\)')
+        remote=${local##*/}
       elif [[ $mode == "down" ]]; then
         if [[ $primarycmd == 'rm' ]]; then
           msg="\033[31;1mfailed:\033[0m deleting http://$cdnurl/"$'\n'"is a directory: http://$cdnurl/"
@@ -1152,16 +1151,15 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
         fi
       fi
     elif [[ $mode == "down" ]]; then
-      remotefile=$(expr "//$remote" : '.*/\(.*\)')
+      remotefile=${remote##*/}
 
-      if [[ ${local:$(expr ${#local} - 1):1} != '/' ]]; then # if the local path doesn't end with a /...
+      if [[ ${local:(-1)} != '/' ]]; then # if the local path doesn't end with a /...
         if [[ -d "$local" ]]; then
           # if $local refers to an existing directory nevertheless,
           # the filename should be the same as the remote filename
           local+="/$remotefile"
         elif [[ $local != '/dev/null' ]]; then
-          localfile=$(expr "//$local" : '.*/\(.*\)')
-          remotefile=$(expr "//$remote" : '.*/\(.*\)')
+          localfile=${local##*/}
 
           if [[ ( ! $localfile =~ '.' ) && $remotefile =~ '.' ]]; then
             # if the localfile has no extension but the remote
@@ -1179,15 +1177,15 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
             # the local filename should be the same as the remote
             local+="/$remotefile"
           else
-            if [[ ! ( "${local%\/*}" == $local || -d "${local%\/*}" ) ]]; then
+            if [[ ! ( "${local%/*}" == $local || -d "${local%/*}" ) ]]; then
               # if the local path without the filename doesn't exist, and the
               # path is not simply the filename (which is the case when downloading
               # into the current folder and referring to the destinations by
               # filename alone, create it.
               if [[ $inputflags =~ "p" ]]; then
-                mkdir -p "${local%\/*}"
+                mkdir -p "${local%/*}"
               else
-                msg="\033[31;1mfailed:\033[0m http://$cdnurl/${remote// /%20} -> $local"$'\n'"no such directory: ${local%\/*}"
+                msg="\033[31;1mfailed:\033[0m http://$cdnurl/${remote// /%20} -> $local"$'\n'"no such directory: ${local%/*}"
                 display_message "$msg" >&2
                 exit 1
               fi
@@ -1277,7 +1275,7 @@ elif [[ $primarycmd == 'mkdir' ]]; then
       word_wrap $(tput cols) 0 $msg >&2
     else
       if [[ $inputflags =~ "p" ]]; then
-        serverbase="${serverdefault%%\/*}"
+        serverbase="${serverdefault%%/*}"
         if [[ $serverbase != $serverdefault ]]; then
           curl "ftp://$serverbase/" -Q "SITE mkdir /${serverdefault#*\/}/$destination/" > /dev/null 2> /dev/null
           result=$?
@@ -1290,19 +1288,19 @@ elif [[ $primarycmd == 'mkdir' ]]; then
           alreadyexists=''
           tocreate=''
 
-          if [[ "${destination%\/*}" == $destination || $destination == $(expr "//$destination" : '.*/\(.*\)') ]]; then
+          if [[ "${destination%/*}" == $destination || $destination == ${destination##*/} ]]; then
             tocreate=$destination
           else
-            if [[ $(curl "ftp://$serverdefault/${destination%%\/*}/" > /dev/null 2> /dev/null) -eq 0 ]]; then
-              alreadyexists+="${destination%%\/*}"
+            if [[ $(curl "ftp://$serverdefault/${destination%%/*}/" > /dev/null 2> /dev/null) -eq 0 ]]; then
+              alreadyexists+="${destination%%/*}"
               tocreate="${destination#*\/}"
 
               while [[ $tocreate != "${tocreate#*\/}" ]]; do
-                curl "ftp://$serverdefault/$alreadyexists/${tocreate%%\/*}/" > /dev/null 2> /dev/null
+                curl "ftp://$serverdefault/$alreadyexists/${tocreate%%/*}/" > /dev/null 2> /dev/null
                 result=$?
 
                 if [[ $result -eq 0 ]]; then
-                  alreadyexists+="/${tocreate%%\/*}"
+                  alreadyexists+="/${tocreate%%/*}"
                   tocreate=${tocreate#*\/}
                 else
                   break
@@ -1412,7 +1410,7 @@ elif [[ $primarycmd == 'ls' || $primarycmd == 'll' ]]; then
 
   remote=${args[0]#cdn:\/\/}
 
-  endchar=${remote:$(expr ${#remote} - 1):1}
+  endchar=${remote:(-1)}
 
   if [[ $endchar != '/' && ! -z $remote ]]; then
     remote+='/'

--- a/beluga-cli
+++ b/beluga-cli
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # beluga-cli
-VERSION_NUMBER="v0.6.4"
+VERSION_NUMBER="v0.6.5"
 # exit codes:
 #  0 success
 #  1 failure: operation aborted

--- a/beluga-cli
+++ b/beluga-cli
@@ -383,11 +383,11 @@ display_help_page ( ) {
   center_text "\033[1mfile manipulation\033[0m\n"
   echo -en "     \033[1mcp\033[0m     "
   word_wrap $(expr $(tput cols) - 5) a-12 "copy a file to, from, or within the origin, resulting in duplicate copies at the source and destination."
-  word_wrap $(expr $(tput cols) - 5) 1:12-19 "usage: \033[37mbeluga-cli \033[37mcp \033[0m[\033[37m-is\033[0m] <\033[37mlocalpath\033[0m> <\033[37mcdn://uri\033[0m> or <\033[37mcdn://uri\033[0m> <\033[37mlocalpath\033[0m> or <\033[37mcdn://uri\033[0m> <\033[37mcdn://uri\033[0m>"
+  word_wrap $(expr $(tput cols) - 5) 1:12-19 "usage: \033[37mbeluga-cli \033[37mcp \033[0m[\033[37m-ips\033[0m] <\033[37mlocalpath\033[0m> <\033[37mcdn://uri\033[0m> or <\033[37mcdn://uri\033[0m> <\033[37mlocalpath\033[0m> or <\033[37mcdn://uri\033[0m> <\033[37mcdn://uri\033[0m>"
   echo
   echo -en "     \033[1mmv\033[0m     "
   word_wrap $(expr $(tput cols) - 5) a-12 "move a file to, from, or within the server, so that the original copy is deleted and only the new one at the destination is kept."
-  word_wrap $(expr $(tput cols) - 5) 1:12-19 "usage: \033[37mbeluga-cli \033[37mmv \033[0m[\033[37m-is\033[0m] <\033[37mlocalpath\033[0m> <\033[37mcdn://uri\033[0m> or <\033[37mcdn://uri\033[0m> <\033[37mlocalpath\033[0m> or <\033[37mcdn://uri\033[0m> <\033[37mcdn://uri\033[0m>"
+  word_wrap $(expr $(tput cols) - 5) 1:12-19 "usage: \033[37mbeluga-cli \033[37mmv \033[0m[\033[37m-ips\033[0m] <\033[37mlocalpath\033[0m> <\033[37mcdn://uri\033[0m> or <\033[37mcdn://uri\033[0m> <\033[37mlocalpath\033[0m> or <\033[37mcdn://uri\033[0m> <\033[37mcdn://uri\033[0m>"
   echo
   echo -en "     \033[1mrm\033[0m     "
   word_wrap $(expr $(tput cols) - 5) a-12 "delete a remote file or directory."
@@ -428,7 +428,7 @@ display_help_page ( ) {
   word_wrap $(expr $(tput cols) - 5) 1:12-19 "usage: \033[37mbeluga-cli \033[0m[<\033[37mcommand\033[0m>] \033[37mhelp\033[0m"
   echo
   echo -en "   \033[1mconfig\033[0m   "
-  word_wrap $(expr $(tput cols) - 5) a-12 "set up server/CDN credentials and other information; see the 'configuration' section below for more details."
+  word_wrap $(expr $(tput cols) - 5) a-12 "set up server/cdn credentials and other information; see the \`\`configuration'' section below for more details."
   word_wrap $(expr $(tput cols) - 5) 1:12-19 "usage: \033[37mbeluga-cli \033[37mconfig\033[0m"
   echo
   echo -e "\n \033[1;4mpossible flags\033[0;1m:\033[0m"
@@ -437,7 +437,7 @@ display_help_page ( ) {
   word_wrap $(expr $(tput cols) - 5) a-12 "if a remote file may be modified by the specified command, beluga-cli will request invalidation of that uri after the operation is complete."
   echo
   echo -en "     \033[1m-p\033[0m     "
-  word_wrap $(expr $(tput cols) - 5) a-12 "create all intermediate directories in the specified path as needed."
+  word_wrap $(expr $(tput cols) - 5) a-12 "create all intermediate directories in the specified path (the destination path, when used with mv or cp commands) as needed."
   echo
   echo -en "     \033[1m-r\033[0m     "
   word_wrap $(expr $(tput cols) - 5) a-12 "delete all contents of the specified directory recursively."
@@ -452,14 +452,14 @@ display_help_page ( ) {
   word_wrap $(expr $(tput cols) - 5) 5 "in order to get everything working correctly before you start using beluga-cli, you must run the command \033[37mbeluga-cli config\033[0m to define the location and credentials used for your origin, the credentials used for belugacdn, and so on."
   echo
   if [[ -z $cdnurl ]]; then
-    word_wrap $(expr $(tput cols) - 5) 5 "note that the \"origin server location\" should include the entire path used as the origin on belugacdn. if you entered an additional path in your property's settings page on beluga, include it here. if you use beluga's origin solution, this may also include a directory with your property name (e.g. X.X.X.X/cdn.your.site/)"
+    word_wrap $(expr $(tput cols) - 5) 5 "note that the \`\`origin server location'' should include the entire path used as the origin on belugacdn. if you entered an additional path in your property's settings page on beluga, include it here. if you use beluga's origin solution, this may also include a directory with your property name (e.g. X.X.X.X/cdn.your.site/)"
   else
-    word_wrap $(expr $(tput cols) - 5) 5 "note that the \"origin server location\" should include the entire path used as the origin on belugacdn. if you entered an additional path in your property's settings page on beluga, include it here. if you use beluga's origin solution, this may also include a directory with your property name (e.g. X.X.X.X/$cdnurl/)"
+    word_wrap $(expr $(tput cols) - 5) 5 "note that the \`\`origin server location'' should include the entire path used as the origin on belugacdn. if you entered an additional path in your property's settings page on beluga, include it here. if you use beluga's origin solution, this may also include a directory with your property name (e.g. X.X.X.X/$cdnurl/)"
   fi
   echo
   word_wrap $(expr $(tput cols) - 5) 5 "\033[1mcaution:\033[0m your origin server username and password will be stored & transmitted as plain text, so ensure they are not used elsewhere."
   echo
-  word_wrap $(expr $(tput cols) - 5) 5 "on the other hand, although you will be prompted for your belugacdn username and password if you choose to create a new token during the setup & configuration process, these are only used for generating the token and are not stored anywhere."
+  word_wrap $(expr $(tput cols) - 5) 5 "on the other hand, although you will be prompted for your belugacdn username and password if you choose to create a new token during the setup & configuration process, these are only used once (for basic authentication, i.e. transmitted in base64) to generate the token, and are not stored anywhere."
   echo
   echo -e " \033[1;4mnotes\033[0;1m:\033[0m"
   echo

--- a/beluga-cli
+++ b/beluga-cli
@@ -208,7 +208,6 @@ display_message ( ) {
 # exit codes:
 #  0 success
 #  1 failure
-# todo: improve coverage of potential curl results
 validate_curl_result ( ) {
   local res=$1
 
@@ -626,7 +625,7 @@ else
     profilename="default"
   fi
 
-  legalflags="isrp"
+  legalflags="isrpc"
 
   if [[ $inputflags != $(echo $inputflags | tr -dc $legalflags ) ]]; then
     inputflags=${inputflags//s/}
@@ -927,6 +926,7 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
       local="$PWD/${local:2}"
     elif [[ ${local:0:1} == '~' ]]; then
       local=${local/\~/$HOME}
+      # TODO: is there a situation where this is really needed?
     fi
   fi
 
@@ -976,7 +976,11 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
       display_message "$msg" >&2
 
       if [[ $result -eq 0 ]]; then
-        curl -T "$HOME/.beluga-cli/.curltmp" "ftp://$serverdefault/$destination" --ftp-create-dirs 2> /dev/null
+        if [[ $inputflags =~ "p" ]]; then
+          curl -T "$HOME/.beluga-cli/.curltmp" "ftp://$serverdefault/$destination" --ftp-create-dirs 2> /dev/null
+        else
+          curl -T "$HOME/.beluga-cli/.curltmp" "ftp://$serverdefault/$destination" 2> /dev/null
+        fi
         result=$?
         rm "$HOME/.beluga-cli/.curltmp"
       fi
@@ -1128,11 +1132,19 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
     if [[ $mode == "up" ]]; then
       if [[ $curroperation == "cp" ]]; then
         msg="\033[1;92muploading:\033[0m $local -> http://$cdnurl/${remote// /%20}"
-        curl -T "$local" "ftp://$serverdefault/$remote" --ftp-create-dirs 2> /dev/null
+        if [[ $inputflags =~ "p" ]]; then
+          curl -T "$local" "ftp://$serverdefault/$remote" --ftp-create-dirs 2> /dev/null
+        else
+          curl -T "$local" "ftp://$serverdefault/$remote" 2> /dev/null
+        fi
         result=$?
       elif [[ $curroperation == "mv" ]]; then
         msg="\033[1;92mmoving:\033[0m $local -> http://$cdnurl/${remote// /%20}"
-        curl -T "$local" "ftp://$serverdefault/$remote" --ftp-create-dirs 2> /dev/null
+        if [[ $inputflags =~ "p" ]]; then
+          curl -T "$local" "ftp://$serverdefault/$remote" --ftp-create-dirs 2> /dev/null
+        else
+          curl -T "$local" "ftp://$serverdefault/$remote" 2> /dev/null
+        fi
         result=$?
         if [[ $result -eq 0 ]]; then
           rm $local

--- a/beluga-cli
+++ b/beluga-cli
@@ -1168,7 +1168,13 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
             # file does, assume it is meant to refer to a directory
             if [[ ! ( -d "$local" ) ]]; then
               # if the directory doesn't exist, create it
-              mkdir -p "$local"
+              if [[ $inputflags =~ "p" ]]; then
+                mkdir -p "$local"
+              else
+                msg="\033[31;1mfailed:\033[0m http://$cdnurl/${remote// /%20} -> $local"$'\n'"no such directory: $local"
+                display_message "$msg" >&2
+                exit 1
+              fi
             fi
             # the local filename should be the same as the remote
             local+="/$remotefile"
@@ -1178,13 +1184,25 @@ elif [[ $primarycmd == 'cp' || $primarycmd == 'mv' || $primarycmd == 'rm' ]]; th
               # path is not simply the filename (which is the case when downloading
               # into the current folder and referring to the destinations by
               # filename alone, create it.
-              mkdir -p "${local%\/*}"
+              if [[ $inputflags =~ "p" ]]; then
+                mkdir -p "${local%\/*}"
+              else
+                msg="\033[31;1mfailed:\033[0m http://$cdnurl/${remote// /%20} -> $local"$'\n'"no such directory: ${local%\/*}"
+                display_message "$msg" >&2
+                exit 1
+              fi
             fi
           fi
         fi
       else # if the local path does end with /
         if [[ ! -d "$local" ]]; then # create the directory if it didn't already exist
-          mkdir -p "$local"
+          if [[ $inputflags =~ "p" ]]; then
+            mkdir -p "$local"
+          else
+            msg="\033[31;1mfailed:\033[0m http://$cdnurl/${remote// /%20} -> $local"$'\n'"no such directory: $local"
+            display_message "$msg" >&2
+            exit 1
+          fi
         fi
 
         local+="$remotefile"


### PR DESCRIPTION
* `cp` and `mv` commands will no longer create intermediate directories in the destination path by default—however, this behavior is still available when the flag `-p` is applied.